### PR TITLE
Switch back to official node-ffi release. Kjunichi's fork was merged.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 
   "dependencies": {
     "buffertools": "~2.1.2",
-    "ffi": "git+https://github.com/kjunichi/node-ffi.git#bad796888ad564bbc6a15b73579223b8f118605e",
+    "ffi": "~1.3.0",
     "ref": "~0.3.2",
     "ref-struct": "~0.0.6",
     "ref-array": "~0.0.4",


### PR DESCRIPTION
Changes related to new node-ffi release 1.3.0.