### PR TITLE
replaced the old list(url) of bootstrap nodes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var toxWithEncData = new toxcore.Tox({
   pass: 'myPassphrase'
 });
 
-// Bootstrap from nodes (see a list at: https://wiki.tox.im/Nodes)
+// Bootstrap from nodes (see a list at: https://wiki.tox.chat/users/nodes)
 tox.bootstrapSync('23.226.230.47', 33445, 'A09162D68618E742FFBCA1C2C70385E6679604B2D80EA6E84AD0996A1AC8A074'); // stal
 tox.bootstrapSync('104.219.184.206', 443, '8CD087E31C67568103E8C2A28653337E90E6B8EDA0D765D57C6B5172B4F1F04C'); // Jfreegman
 

--- a/examples/bin/file-transfer-example.js
+++ b/examples/bin/file-transfer-example.js
@@ -69,7 +69,10 @@ var fixRecvFilename = function(filename) {
   return filename;
 };
 
-// Specify nodes to bootstrap from
+/**
+ * Bootstrap tox via hardcoded nodes.
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
+ */
 var nodes = [
   { maintainer: 'saneki',
     address: '96.31.85.154',

--- a/examples/bin/old-groupchats-sync-example.js
+++ b/examples/bin/old-groupchats-sync-example.js
@@ -29,7 +29,10 @@ var TOX_CHAT_CHANGE_PEER_ADD = 0;
 var TOX_CHAT_CHANGE_PEER_DEL = 1;
 var TOX_CHAT_CHANGE_PEER_NAME = 2;
 
-// Specify nodes to bootstrap from
+/**
+ * Bootstrap tox via hardcoded nodes.
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
+ */
 var nodes = [
   { maintainer: 'saneki',
     address: '96.31.85.154',

--- a/examples/bin/old/promises-example.js
+++ b/examples/bin/old/promises-example.js
@@ -35,7 +35,7 @@ var groupchats = {
 
 /**
  * Bootstrap tox via hardcoded nodes.
- * For more nodes, see: https://wiki.tox.im/Nodes
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
 var bootstrap = function(callback) {
   // Define nodes to bootstrap from

--- a/examples/bin/old/sync-example.js
+++ b/examples/bin/old/sync-example.js
@@ -22,7 +22,10 @@
 var toxcore = require('toxcore');
 var tox = new toxcore.Tox();
 
-// Specify nodes to bootstrap from
+/**
+ * Bootstrap tox via hardcoded nodes.
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
+ */
 var nodes = [
   { maintainer: 'Impyy',
     address: '178.62.250.138',

--- a/examples/bin/packet-simulation.js
+++ b/examples/bin/packet-simulation.js
@@ -23,8 +23,11 @@ var tx = new toxcore.Tox(), rx = new toxcore.Tox();
 var LOSSLESS_CHANNEL = 160;
 var LOSSY_CHANNEL = 200;
 
-// Specify nodes to bootstrap from
-var nodes = [
+/*
+ * Bootstrap tox via hardcoded nodes.
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
+ */
+ var nodes = [
   { maintainer: 'saneki',
     address: '96.31.85.154',
     port: 33445,

--- a/examples/bin/promises-example.js
+++ b/examples/bin/promises-example.js
@@ -31,7 +31,7 @@ var tox = new toxcore.Tox();
 
 /**
  * Bootstrap tox via hardcoded nodes.
- * For more nodes, see: https://wiki.tox.im/Nodes
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
  */
 var bootstrap = function(callback) {
   // Define nodes to bootstrap from

--- a/examples/bin/sync-example.js
+++ b/examples/bin/sync-example.js
@@ -25,8 +25,11 @@ var path = require('path');
 var toxcore = !testingMode ? require('toxcore') : require(path.join(__dirname, '..', '..', 'lib', 'main'));
 var tox = new toxcore.Tox();
 
-// Specify nodes to bootstrap from
-var nodes = [
+/**
+ * Bootstrap tox via hardcoded nodes.
+ * For more nodes, see: https://wiki.tox.chat/users/nodes
+ */
+ var nodes = [
   { maintainer: 'saneki',
     address: '96.31.85.154',
     port: 33445,


### PR DESCRIPTION
Replaced the old link to the list of bootstrap nodes. Also added the link to some example files which don't specify the list of bootstrap nodes. 